### PR TITLE
🐛 Fix: Resolve 404 routing error on application startup

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function HomePage() {
-  // Redirect to dashboard as the main application page
-  redirect('/dashboard');
-}


### PR DESCRIPTION
## Problem
The portfolio tracker application returns a **404 error** when accessing the root URL (`http://localhost:3000`).

### Root Cause
The issue is caused by a **routing conflict** in the Next.js App Router structure:

1. **Conflicting Pages**: 
   - `src/app/page.tsx` redirects to `/dashboard`
   - `src/app/(dashboard)/page.tsx` serves the actual dashboard

2. **Route Group Behavior**: 
   - `(dashboard)` is a Next.js route group that doesn't add to the URL path
   - The dashboard is actually served at `/` (root), not `/dashboard`

3. **The Conflict**:
   - Root page tries to redirect to `/dashboard`
   - But `/dashboard` doesn't exist (dashboard is at `/`)
   - Result: **404 Not Found**

## Solution
✅ **Remove the conflicting root page** (`src/app/page.tsx`)

This allows the dashboard to be properly served at the root URL via the route group structure:
- `/` → Dashboard (from `src/app/(dashboard)/page.tsx`)
- `/holdings` → Holdings page
- `/transactions` → Transactions page  
- `/analysis` → Analysis page

## Testing
After this fix:
- ✅ Root URL loads the dashboard correctly
- ✅ Navigation between pages works
- ✅ Welcome screen appears for new users
- ✅ All UI components render properly

## Technical Details
**Next.js App Router Route Groups**:
- `(dashboard)` folder creates a route group
- Route groups organize routes without affecting URL structure
- Files inside `(dashboard)` are served at the parent path level

**Before**: `/` → redirects to `/dashboard` → 404 (doesn't exist)
**After**: `/` → serves dashboard directly → ✅ works

## Impact
- 🎯 **Fixes**: Application 404 error on startup
- 📱 **Improves**: User experience and accessibility  
- 🚀 **Enables**: Proper portfolio tracker functionality

This is a critical fix that enables the application to load correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)