### PR TITLE
fix: resolve pre-existing build and test failures

### DIFF
--- a/src/components/dashboard/dashboard-container-rgl.tsx
+++ b/src/components/dashboard/dashboard-container-rgl.tsx
@@ -129,7 +129,7 @@ const DashboardContainerRGLComponent = ({
   disableDragDrop = false,
 }: DashboardContainerRGLProps) => {
   // Get container width for react-grid-layout v2.x
-  const { ref, width: measuredWidth } = useContainerWidth();
+  const { containerRef, width: measuredWidth } = useContainerWidth();
 
   const {
     config,
@@ -349,7 +349,7 @@ const DashboardContainerRGLComponent = ({
   }
 
   return (
-    <div ref={ref} className="space-y-4">
+    <div ref={containerRef} className="space-y-4">
       <StaleDataBanner lastUpdated={null} thresholdMinutes={15} />
 
       {priceLoading && (

--- a/src/lib/services/__tests__/dashboard-config.test.ts
+++ b/src/lib/services/__tests__/dashboard-config.test.ts
@@ -194,6 +194,11 @@ describe('Dashboard Configuration Service', () => {
           widgetSpans: { 'growth-chart': 2 },
           densePacking: true,
           widgetRowSpans: { 'growth-chart': 2 },
+          widgetSettings: {
+            'category-breakdown': {
+              showPieChart: false,
+            },
+          },
           lastUpdated: '2025-01-01T00:00:00Z',
         };
 
@@ -244,6 +249,11 @@ describe('Dashboard Configuration Service', () => {
           widgetSpans: { 'growth-chart': 2, 'category-breakdown': 2 },
           densePacking: true,
           widgetRowSpans: { 'growth-chart': 3, 'category-breakdown': 2 },
+          widgetSettings: {
+            'category-breakdown': {
+              showPieChart: false,
+            },
+          },
           lastUpdated: '2025-01-01T00:00:00Z',
         };
 
@@ -304,6 +314,11 @@ describe('Dashboard Configuration Service', () => {
           widgetSpans: {},
           densePacking: false,
           widgetRowSpans: {},
+          widgetSettings: {
+            'category-breakdown': {
+              showPieChart: false,
+            },
+          },
           lastUpdated: '2025-01-01T00:00:00Z',
         };
 
@@ -346,6 +361,11 @@ describe('Dashboard Configuration Service', () => {
           widgetSpans: { 'growth-chart': 2, 'category-breakdown': 2 },
           densePacking: false,
           widgetRowSpans: {},
+          widgetSettings: {
+            'category-breakdown': {
+              showPieChart: false,
+            },
+          },
           lastUpdated: '2025-01-01T00:00:00Z',
         };
 
@@ -397,6 +417,11 @@ describe('Dashboard Configuration Service', () => {
           widgetSpans: { 'growth-chart': 2 },
           densePacking: true,
           widgetRowSpans: { 'growth-chart': 3, 'category-breakdown': 2 },
+          widgetSettings: {
+            'category-breakdown': {
+              showPieChart: false,
+            },
+          },
           lastUpdated: '2025-01-01T00:00:00Z',
         };
 
@@ -435,6 +460,11 @@ describe('Dashboard Configuration Service', () => {
           widgetSpans: { 'growth-chart': 2 },
           densePacking: true,
           widgetRowSpans: { 'growth-chart': 3, 'recent-activity': 2 },
+          widgetSettings: {
+            'category-breakdown': {
+              showPieChart: false,
+            },
+          },
           lastUpdated: '2025-01-01T00:00:00Z',
         };
 
@@ -485,6 +515,11 @@ describe('Dashboard Configuration Service', () => {
           widgetSpans: { 'growth-chart': 2 },
           densePacking: false,
           widgetRowSpans: {},
+          widgetSettings: {
+            'category-breakdown': {
+              showPieChart: false,
+            },
+          },
           lastUpdated: '2025-01-01T00:00:00Z',
         };
 
@@ -521,6 +556,11 @@ describe('Dashboard Configuration Service', () => {
           widgetSpans: { 'growth-chart': 2, 'category-breakdown': 2 },
           densePacking: false,
           widgetRowSpans: {},
+          widgetSettings: {
+            'category-breakdown': {
+              showPieChart: false,
+            },
+          },
           lastUpdated: '2025-01-01T00:00:00Z',
         };
 
@@ -557,6 +597,11 @@ describe('Dashboard Configuration Service', () => {
           widgetSpans: { 'growth-chart': 2 },
           densePacking: false,
           widgetRowSpans: { 'growth-chart': 3 },
+          widgetSettings: {
+            'category-breakdown': {
+              showPieChart: false,
+            },
+          },
           lastUpdated: '2025-01-01T00:00:00Z',
         };
 
@@ -603,6 +648,11 @@ describe('Dashboard Configuration Service', () => {
           widgetSpans: { 'growth-chart': 2 },
           densePacking: true,
           widgetRowSpans: { 'growth-chart': 3, 'category-breakdown': 2 },
+          widgetSettings: {
+            'category-breakdown': {
+              showPieChart: false,
+            },
+          },
           lastUpdated: '2025-01-01T00:00:00Z',
         };
 
@@ -649,6 +699,11 @@ describe('Dashboard Configuration Service', () => {
           widgetSpans: {},
           densePacking: false,
           widgetRowSpans: {},
+          widgetSettings: {
+            'category-breakdown': {
+              showPieChart: false,
+            },
+          },
           lastUpdated: '2025-01-01T00:00:00Z',
         };
 
@@ -699,6 +754,11 @@ describe('Dashboard Configuration Service', () => {
         widgetSpans: {},
         densePacking: false,
         widgetRowSpans: {},
+        widgetSettings: {
+          'category-breakdown': {
+            showPieChart: false,
+          },
+        },
         useReactGridLayout: false,
         rglLayouts: undefined,
         lastUpdated: '2025-01-01T00:00:00Z',
@@ -755,6 +815,11 @@ describe('Dashboard Configuration Service', () => {
         widgetSpans: {},
         densePacking: false,
         widgetRowSpans: {},
+        widgetSettings: {
+          'category-breakdown': {
+            showPieChart: false,
+          },
+        },
         useReactGridLayout: false,
         rglLayouts: existingLayouts,
         lastUpdated: '2025-01-01T00:00:00Z',
@@ -808,6 +873,11 @@ describe('Dashboard Configuration Service', () => {
         widgetSpans: {},
         densePacking: false,
         widgetRowSpans: {},
+        widgetSettings: {
+          'category-breakdown': {
+            showPieChart: false,
+          },
+        },
         useReactGridLayout: true,
         rglLayouts: existingLayouts,
         lastUpdated: '2025-01-01T00:00:00Z',
@@ -851,6 +921,11 @@ describe('Dashboard Configuration Service', () => {
         widgetSpans: {},
         densePacking: false,
         widgetRowSpans: {},
+        widgetSettings: {
+          'category-breakdown': {
+            showPieChart: false,
+          },
+        },
         lastUpdated: '2025-01-01T00:00:00Z',
       };
 
@@ -882,6 +957,11 @@ describe('Dashboard Configuration Service', () => {
         widgetSpans: {},
         densePacking: false,
         widgetRowSpans: {},
+        widgetSettings: {
+          'category-breakdown': {
+            showPieChart: false,
+          },
+        },
         lastUpdated: '2025-01-01T00:00:00Z',
       };
 


### PR DESCRIPTION
## Summary

- Fix build failure in `dashboard-container-rgl.tsx` - the `useContainerWidth` hook from react-grid-layout v2.x returns `containerRef`, not `ref`
- Fix 4 test failures in `dashboard-config.test.ts` by adding the required `widgetSettings` property to 16 test configuration objects
- Fix 5 test failures in `category-breakdown-widget.test.tsx` by updating tests to match the component's actual compact view logic

## Details

### Build Fix
The `useContainerWidth` hook from react-grid-layout v2.x returns:
```typescript
interface UseContainerWidthResult {
  width: number;
  mounted: boolean;
  containerRef: RefObject<HTMLDivElement | null>;  // NOT 'ref'
  measureWidth: () => void;
}
```

### Test Fixes
The category-breakdown widget's pie chart visibility is determined by:
- **1-column widgets**: `rowSpan >= 4` required for pie chart
- **2-column widgets**: `rowSpan >= 2` required for pie chart

Tests were updated to use the correct rowSpan values.

## Test plan
- [x] `npm run type-check` - build fix verified (remaining errors are pre-existing in other files)
- [x] `npm run test -- --run src/lib/services/__tests__/dashboard-config.test.ts` - 19/20 passing (1 pre-existing failure unrelated to this fix)
- [x] `npm run test -- --run src/components/dashboard/widgets/__tests__/category-breakdown-widget.test.tsx` - 20/20 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)