### PR TITLE
Remove Beta and Coming Soon badges from navigation

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -22,7 +22,15 @@ import { cn } from '@/lib/utils';
 
 type NavRoute = {
   name: string;
-  href: '/' | '/holdings' | '/transactions' | '/analysis' | '/performance' | '/allocation' | '/reports' | '/settings';
+  href:
+    | '/'
+    | '/holdings'
+    | '/transactions'
+    | '/analysis'
+    | '/performance'
+    | '/allocation'
+    | '/reports'
+    | '/settings';
   icon: typeof Home;
   badge?: 'beta' | 'coming-soon';
 };
@@ -57,13 +65,11 @@ const navigation: NavRoute[] = [
     name: 'Allocation',
     href: '/allocation',
     icon: PieChart,
-    badge: 'beta' as const,
   },
   {
     name: 'Reports',
     href: '/reports',
     icon: FileText,
-    badge: 'coming-soon' as const,
   },
   {
     name: 'Settings',


### PR DESCRIPTION
## Summary
- Remove "Beta" badge from Allocation navigation item
- Remove "Coming Soon" badge from Reports navigation item

Both features are now stable and production-ready, making the badges unnecessary.

## Changes
- **File**: `src/components/layout/sidebar.tsx`
  - Removed `badge: 'beta'` property from Allocation nav item
  - Removed `badge: 'coming-soon'` property from Reports nav item

## Visual Impact
### Before:
- Allocation: Shows blue "Beta" badge with flask icon
- Reports: Shows gray "Coming Soon" badge with clock icon

### After:
- Allocation: No badge, clean navigation item
- Reports: No badge, clean navigation item

## Test Plan
- [x] Code formatted with Prettier
- [x] Branch builds successfully
- [ ] Visual verification: Both navigation items display without badges
- [ ] Navigation links still work correctly to `/allocation` and `/reports`
- [ ] No impact on other navigation items

## Verification Steps
1. Start dev server: `npm run dev`
2. Check sidebar navigation
3. Verify Allocation item has no "Beta" badge
4. Verify Reports item has no "Coming Soon" badge
5. Click both links to confirm navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)