### PR TITLE
fix: skip liabilities before start date in net worth history calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -191,7 +191,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -567,7 +566,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -591,7 +589,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -619,7 +616,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -703,6 +699,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -720,6 +717,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -737,6 +735,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -754,6 +753,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -771,6 +771,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -788,6 +789,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -805,6 +807,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -822,6 +825,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -839,6 +843,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -856,6 +861,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -873,6 +879,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -890,6 +897,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -907,6 +915,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -924,6 +933,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -941,6 +951,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -958,6 +969,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -975,6 +987,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -992,6 +1005,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1009,6 +1023,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1026,6 +1041,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1043,6 +1059,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1060,6 +1077,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1077,6 +1095,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1094,6 +1113,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1111,6 +1131,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1128,6 +1149,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1737,7 +1759,6 @@
       "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.55.1"
       },
@@ -3672,7 +3693,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3865,7 +3887,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3876,7 +3897,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3961,7 +3981,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -4568,7 +4587,6 @@
       "integrity": "sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "1.6.1",
         "fast-glob": "^3.3.2",
@@ -4642,7 +4660,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5150,7 +5167,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -5845,7 +5861,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -6031,7 +6046,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -6297,6 +6313,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6362,7 +6379,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6532,7 +6548,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8322,7 +8337,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8352,7 +8366,6 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -8440,7 +8453,6 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
       "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "fast-png": "^6.2.0",
@@ -8915,6 +8927,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9827,7 +9840,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9974,7 +9986,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10078,6 +10089,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10093,6 +10105,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10182,7 +10195,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10226,7 +10238,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -10278,7 +10289,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
       "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -10295,7 +10305,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -11613,7 +11624,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -11807,7 +11817,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12056,7 +12065,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12303,6 +12311,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12906,6 +12915,7 @@
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -12929,6 +12939,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -12953,7 +12964,6 @@
       "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "1.6.1",
         "@vitest/runner": "1.6.1",
@@ -13871,7 +13881,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/lib/services/planning/__tests__/net-worth-service.test.ts
+++ b/src/lib/services/planning/__tests__/net-worth-service.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Net Worth Service Unit Tests
+ *
+ * Tests net worth calculation including:
+ * - Asset valuation using price history
+ * - Liability balance inclusion/exclusion based on start dates
+ * - Historical net worth time series generation
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Decimal } from 'decimal.js';
+
+// Mock database before importing the service
+vi.mock('@/lib/db/schema', () => ({
+  db: {
+    getHoldingsByPortfolio: vi.fn(() => Promise.resolve([])),
+    getLiabilitiesByPortfolio: vi.fn(() => Promise.resolve([])),
+    assets: {
+      bulkGet: vi.fn(() => Promise.resolve([])),
+    },
+    getPriceHistoryByAsset: vi.fn(() => Promise.resolve([])),
+    getLiabilityPayments: vi.fn(() => Promise.resolve([])),
+  },
+}));
+
+import {
+  getNetWorthHistory,
+  getCurrentNetWorth,
+} from '../net-worth-service';
+import { db } from '@/lib/db/schema';
+
+describe('getNetWorthHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return monthly data points even with no holdings or liabilities', async () => {
+    const startDate = new Date('2025-01-01');
+    const endDate = new Date('2025-03-31');
+
+    const history = await getNetWorthHistory('portfolio-1', startDate, endDate);
+
+    // Should have 3 months: Jan, Feb, Mar
+    expect(history.length).toBe(3);
+    expect(history[0].assets).toBe(0);
+    expect(history[0].liabilities).toBe(0);
+    expect(history[0].netWorth).toBe(0);
+  });
+
+  it('should calculate asset values from holdings and price history', async () => {
+    const holdingId = 'holding-1';
+    const assetId = 'asset-1';
+
+    vi.mocked(db.getHoldingsByPortfolio).mockResolvedValue([
+      {
+        id: holdingId,
+        portfolioId: 'portfolio-1',
+        assetId,
+        quantity: 10,
+        averageCost: 100,
+        ownershipPercentage: 100,
+      } as any,
+    ]);
+
+    vi.mocked(db.getLiabilitiesByPortfolio).mockResolvedValue([]);
+
+    vi.mocked(db.assets.bulkGet).mockResolvedValue([
+      {
+        id: assetId,
+        symbol: 'AAPL',
+        name: 'Apple',
+        currentPrice: 150,
+      } as any,
+    ]);
+
+    vi.mocked(db.getPriceHistoryByAsset).mockResolvedValue([
+      { assetId, date: '2025-01-15', close: 140, open: 138, high: 142, low: 137, volume: 1000 },
+      { assetId, date: '2025-02-15', close: 150, open: 145, high: 155, low: 143, volume: 1200 },
+    ] as any);
+
+    const startDate = new Date('2025-01-01');
+    const endDate = new Date('2025-02-28');
+
+    const history = await getNetWorthHistory('portfolio-1', startDate, endDate);
+
+    expect(history.length).toBe(2);
+    // Jan 31: most recent price on or before is Jan 15 (140), 10 shares = 1400
+    expect(history[0].assets).toBe(1400);
+    // Feb 28: most recent price on or before is Feb 15 (150), 10 shares = 1500
+    expect(history[1].assets).toBe(1500);
+  });
+
+  it('should skip liabilities whose start date is after the calculation date', async () => {
+    vi.mocked(db.getHoldingsByPortfolio).mockResolvedValue([]);
+
+    // Liability starts in March 2025 - should NOT appear in Jan/Feb calculations
+    vi.mocked(db.getLiabilitiesByPortfolio).mockResolvedValue([
+      {
+        id: 'liability-1',
+        portfolioId: 'portfolio-1',
+        name: 'Car Loan',
+        balance: 20000,
+        interestRate: 0.05,
+        payment: 500,
+        startDate: '2025-03-01',
+        createdAt: '2025-03-01',
+        updatedAt: '2025-03-01',
+      },
+    ]);
+
+    vi.mocked(db.assets.bulkGet).mockResolvedValue([]);
+    vi.mocked(db.getLiabilityPayments).mockResolvedValue([]);
+
+    const startDate = new Date('2025-01-01');
+    const endDate = new Date('2025-04-30');
+
+    const history = await getNetWorthHistory('portfolio-1', startDate, endDate);
+
+    // Jan and Feb: liability didn't exist yet, liabilities should be 0
+    expect(history[0].liabilities).toBe(0); // Jan
+    expect(history[1].liabilities).toBe(0); // Feb
+
+    // Mar and Apr: liability exists, should show balance
+    expect(history[2].liabilities).toBe(20000); // Mar
+    expect(history[3].liabilities).toBe(20000); // Apr
+  });
+
+  it('should not throw when liabilities have start dates after history range start', async () => {
+    vi.mocked(db.getHoldingsByPortfolio).mockResolvedValue([]);
+
+    // Liability starts in 2025, but history goes back to 2020
+    vi.mocked(db.getLiabilitiesByPortfolio).mockResolvedValue([
+      {
+        id: 'liability-1',
+        portfolioId: 'portfolio-1',
+        name: 'Mortgage',
+        balance: 300000,
+        interestRate: 0.045,
+        payment: 1500,
+        startDate: '2025-01-15',
+        createdAt: '2025-01-15',
+        updatedAt: '2025-01-15',
+      },
+    ]);
+
+    vi.mocked(db.assets.bulkGet).mockResolvedValue([]);
+    vi.mocked(db.getLiabilityPayments).mockResolvedValue([]);
+
+    const startDate = new Date('2020-01-01');
+    const endDate = new Date('2025-06-30');
+
+    // This should NOT throw - it was the original bug
+    await expect(
+      getNetWorthHistory('portfolio-1', startDate, endDate)
+    ).resolves.not.toThrow();
+
+    const history = await getNetWorthHistory('portfolio-1', startDate, endDate);
+
+    // All months before 2025-01-15 should have 0 liabilities
+    const preLiabilityMonths = history.filter(
+      (p) => p.date < new Date('2025-01-15')
+    );
+    for (const point of preLiabilityMonths) {
+      expect(point.liabilities).toBe(0);
+    }
+
+    // Months from Feb 2025 onward should include the liability
+    const postLiabilityMonths = history.filter(
+      (p) => p.date >= new Date('2025-01-31')
+    );
+    expect(postLiabilityMonths.length).toBeGreaterThan(0);
+    for (const point of postLiabilityMonths) {
+      expect(point.liabilities).toBe(300000);
+    }
+  });
+
+  it('should handle mix of holdings and liabilities correctly', async () => {
+    const assetId = 'asset-1';
+
+    vi.mocked(db.getHoldingsByPortfolio).mockResolvedValue([
+      {
+        id: 'holding-1',
+        portfolioId: 'portfolio-1',
+        assetId,
+        quantity: 100,
+        averageCost: 50,
+        ownershipPercentage: 100,
+      } as any,
+    ]);
+
+    vi.mocked(db.getLiabilitiesByPortfolio).mockResolvedValue([
+      {
+        id: 'liability-1',
+        portfolioId: 'portfolio-1',
+        name: 'Loan',
+        balance: 5000,
+        interestRate: 0.05,
+        payment: 200,
+        startDate: '2025-01-01',
+        createdAt: '2025-01-01',
+        updatedAt: '2025-01-01',
+      },
+    ]);
+
+    vi.mocked(db.assets.bulkGet).mockResolvedValue([
+      { id: assetId, symbol: 'VTI', name: 'Vanguard Total', currentPrice: 200 } as any,
+    ]);
+
+    vi.mocked(db.getPriceHistoryByAsset).mockResolvedValue([
+      { assetId, date: '2025-01-10', close: 200, open: 198, high: 202, low: 197, volume: 500 },
+    ] as any);
+
+    vi.mocked(db.getLiabilityPayments).mockResolvedValue([]);
+
+    const startDate = new Date('2025-01-01');
+    const endDate = new Date('2025-01-31');
+
+    const history = await getNetWorthHistory('portfolio-1', startDate, endDate);
+
+    expect(history.length).toBe(1);
+    // Assets: 100 shares * $200 = $20,000
+    expect(history[0].assets).toBe(20000);
+    // Liabilities: $5,000
+    expect(history[0].liabilities).toBe(5000);
+    // Net worth: $20,000 - $5,000 = $15,000
+    expect(history[0].netWorth).toBe(15000);
+  });
+});
+
+describe('getCurrentNetWorth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return 0 for empty portfolio', async () => {
+    vi.mocked(db.getHoldingsByPortfolio).mockResolvedValue([]);
+    vi.mocked(db.getLiabilitiesByPortfolio).mockResolvedValue([]);
+    vi.mocked(db.assets.bulkGet).mockResolvedValue([]);
+
+    const netWorth = await getCurrentNetWorth('portfolio-1');
+    expect(netWorth).toBe(0);
+  });
+});

--- a/src/lib/services/planning/net-worth-service.ts
+++ b/src/lib/services/planning/net-worth-service.ts
@@ -115,6 +115,10 @@ function calculateNetWorthFromCache(
 
   // Calculate historical liability balances using payment history
   for (const liability of data.liabilities) {
+    // Skip liabilities that didn't exist yet at the calculation date
+    const liabilityStartDate = new Date(liability.startDate);
+    if (date < liabilityStartDate) continue;
+
     const payments = data.liabilityPaymentsMap.get(liability.id) || [];
     const balanceAtDate = calculateLiabilityBalanceAtDate(
       liability,


### PR DESCRIPTION
calculateLiabilityBalanceAtDate throws when targetDate < startDate, which
caused getNetWorthHistory to fail silently when any liability had a start
date after the time range start. This prevented the planning page from
displaying any data. Now skips liabilities that didn't exist at each
calculation date, correctly treating them as zero contribution.

https://claude.ai/code/session_01QgMi4dMkTKpETeZEFTVQq7