### PR TITLE
Remove redundant Tax Settings link from settings page

### DIFF
--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -21,7 +21,6 @@ import {
   Download,
   Upload,
   AlertTriangle,
-  Receipt,
 } from 'lucide-react';
 import { PriceSettings } from '@/components/settings/price-settings';
 import { CsvImportDialog } from '@/components/forms/csv-import-dialog';
@@ -189,29 +188,6 @@ export default function SettingsPage() {
                   setTheme(checked ? 'dark' : 'light')
                 }
               />
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Receipt className="h-5 w-5" />
-              Tax Settings
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <p className="text-sm text-muted-foreground">
-                Configure capital gains tax rates and ESPP/RSU tax tracking
-              </p>
-              <Button
-                variant="outline"
-                className="w-full justify-start"
-                onClick={() => router.push('/settings/tax')}
-              >
-                Manage Tax Settings
-              </Button>
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
The navigation was updated to include a direct link to tax settings,
making the card on the settings page unnecessary.

https://claude.ai/code/session_017yLbSHUxozXq3pmbffeb75