### PR TITLE
fix: Resolve all TypeScript type-check errors in store tests

### DIFF
--- a/src/lib/stores/__tests__/allocation.test.ts
+++ b/src/lib/stores/__tests__/allocation.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useAllocationStore } from '../allocation';
-import { TargetModel, AllocationDimension } from '@/types/allocation';
+import { TargetModel, AllocationDimension, AllocationData } from '@/types/allocation';
 
 // Mock the allocation services
 vi.mock('@/lib/services/allocation/target-service', () => ({
@@ -279,9 +279,9 @@ describe('Allocation Store', () => {
 
   describe('Dimension Selection', () => {
     it('should set selected dimension', () => {
-      useAllocationStore.getState().setSelectedDimension('category');
+      useAllocationStore.getState().setSelectedDimension('sector');
 
-      expect(useAllocationStore.getState().selectedDimension).toBe('category');
+      expect(useAllocationStore.getState().selectedDimension).toBe('sector');
     });
 
     it('should update dimension to region', () => {
@@ -362,12 +362,14 @@ describe('Allocation Store', () => {
 
   describe('Current Allocation', () => {
     it('should set current allocation', () => {
-      const mockAllocation = {
+      const mockAllocation: AllocationData = {
         dimension: 'assetClass' as AllocationDimension,
-        allocations: [
-          { category: 'stocks', value: 80000, percentage: 80, count: 10 },
-          { category: 'bonds', value: 20000, percentage: 20, count: 5 },
+        breakdown: [
+          { category: 'stocks', value: '80000', percentage: 80, count: 10 },
+          { category: 'bonds', value: '20000', percentage: 20, count: 5 },
         ],
+        totalValue: '100000',
+        hasUnclassified: false,
       };
 
       useAllocationStore.getState().setCurrentAllocation(mockAllocation);
@@ -376,9 +378,11 @@ describe('Allocation Store', () => {
     });
 
     it('should allow clearing current allocation', () => {
-      const mockAllocation = {
+      const mockAllocation: AllocationData = {
         dimension: 'assetClass' as AllocationDimension,
-        allocations: [{ category: 'stocks', value: 100000, percentage: 100, count: 1 }],
+        breakdown: [{ category: 'stocks', value: '100000', percentage: 100, count: 1 }],
+        totalValue: '100000',
+        hasUnclassified: false,
       };
 
       useAllocationStore.setState({ currentAllocation: mockAllocation });

--- a/src/lib/stores/__tests__/analysis.test.ts
+++ b/src/lib/stores/__tests__/analysis.test.ts
@@ -22,11 +22,14 @@ vi.mock('@/lib/db', () => ({
 
 vi.mock('@/lib/services/analysis/scoring-service', () => ({
   calculateHealthScore: vi.fn(() => ({
-    overall: 75,
-    diversification: 80,
-    performance: 70,
-    risk: 75,
-    allocation: 80,
+    overallScore: 75,
+    metrics: [
+      { id: 'diversification', name: 'Diversification', score: 80, maxScore: 100, weight: 0.33, status: 'good', details: 'Good diversification' },
+      { id: 'performance', name: 'Performance', score: 70, maxScore: 100, weight: 0.34, status: 'good', details: 'Good performance' },
+      { id: 'volatility', name: 'Volatility', score: 75, maxScore: 100, weight: 0.33, status: 'good', details: 'Low volatility' },
+    ],
+    profile: { id: 'balanced', name: 'Balanced', description: 'Equal weight across all factors', weights: { diversification: 0.33, performance: 0.34, volatility: 0.33 } },
+    calculatedAt: new Date(),
   })),
 }));
 
@@ -110,7 +113,7 @@ describe('Analysis Store', () => {
 
       const state = useAnalysisStore.getState();
       expect(state.health).toBeTruthy();
-      expect(state.health?.overall).toBe(75);
+      expect(state.health?.overallScore).toBe(75);
       expect(state.isCalculating).toBe(false);
       expect(state.error).toBeNull();
     });
@@ -299,8 +302,8 @@ describe('Analysis Store', () => {
           {
             id: 'model-1',
             name: 'Test Model',
-            targets: { stocks: 60, bonds: 40 },
-            dimension: 'assetClass',
+            allocations: { stock: 60, bond: 40 } as Record<string, number>,
+            isSystem: false,
             createdAt: new Date(),
             updatedAt: new Date(),
           },
@@ -341,8 +344,8 @@ describe('Analysis Store', () => {
           {
             id: 'model-1',
             name: 'Test Model',
-            targets: { stocks: 60, bonds: 40 },
-            dimension: 'assetClass',
+            allocations: { stock: 60, bond: 40 } as Record<string, number>,
+            isSystem: false,
             createdAt: new Date(),
             updatedAt: new Date(),
           },
@@ -405,8 +408,8 @@ describe('Analysis Store', () => {
           {
             id: 'model-1',
             name: 'Test Model',
-            targets: { stocks: 60, bonds: 40 },
-            dimension: 'assetClass',
+            allocations: { stock: 60, bond: 40 } as Record<string, number>,
+            isSystem: false,
             createdAt: new Date(),
             updatedAt: new Date(),
           },

--- a/src/lib/stores/__tests__/export.test.ts
+++ b/src/lib/stores/__tests__/export.test.ts
@@ -35,9 +35,10 @@ describe('Export Store', () => {
   describe('startExport', () => {
     it('should start PDF export', () => {
       const config: ReportConfig = {
-        type: 'pdf',
+        type: 'performance',
         portfolioId: 'portfolio-1',
-        includeSummary: true,
+        dateRange: 'YTD',
+        format: 'pdf',
       };
 
       useExportStore.getState().startExport(config);
@@ -45,21 +46,23 @@ describe('Export Store', () => {
       const state = useExportStore.getState();
       expect(state.progress.status).toBe('preparing');
       expect(state.progress.progress).toBe(0);
-      expect(state.progress.message).toBe('Preparing pdf export...');
+      expect(state.progress.message).toBe('Preparing performance export...');
       expect(state.progress.error).toBeUndefined();
     });
 
     it('should start CSV export', () => {
       const config: ReportConfig = {
-        type: 'csv',
+        type: 'transactions',
         portfolioId: 'portfolio-1',
+        dateRange: 'ALL',
+        format: 'csv',
       };
 
       useExportStore.getState().startExport(config);
 
       const state = useExportStore.getState();
       expect(state.progress.status).toBe('preparing');
-      expect(state.progress.message).toBe('Preparing csv export...');
+      expect(state.progress.message).toBe('Preparing transactions export...');
     });
 
     it('should clear previous error on new export', () => {
@@ -73,8 +76,10 @@ describe('Export Store', () => {
       });
 
       const config: ReportConfig = {
-        type: 'pdf',
+        type: 'holdings',
         portfolioId: 'portfolio-1',
+        dateRange: 'YTD',
+        format: 'pdf',
       };
 
       useExportStore.getState().startExport(config);
@@ -92,15 +97,15 @@ describe('Export Store', () => {
       expect(state.progress.progress).toBe(50);
     });
 
-    it('should update status to exporting', () => {
+    it('should update status to generating', () => {
       useExportStore.getState().updateProgress({
-        status: 'exporting',
+        status: 'generating',
         progress: 30,
         message: 'Generating report...',
       });
 
       const state = useExportStore.getState();
-      expect(state.progress.status).toBe('exporting');
+      expect(state.progress.status).toBe('generating');
       expect(state.progress.progress).toBe(30);
       expect(state.progress.message).toBe('Generating report...');
     });
@@ -132,7 +137,7 @@ describe('Export Store', () => {
     it('should preserve existing fields when partially updating', () => {
       useExportStore.setState({
         progress: {
-          status: 'exporting',
+          status: 'generating',
           progress: 50,
           message: 'Generating...',
           error: undefined,
@@ -142,7 +147,7 @@ describe('Export Store', () => {
       useExportStore.getState().updateProgress({ progress: 75 });
 
       const state = useExportStore.getState();
-      expect(state.progress.status).toBe('exporting');
+      expect(state.progress.status).toBe('generating');
       expect(state.progress.progress).toBe(75);
       expect(state.progress.message).toBe('Generating...');
     });
@@ -188,20 +193,22 @@ describe('Export Store', () => {
   describe('Progress Workflow', () => {
     it('should follow typical export workflow', () => {
       const config: ReportConfig = {
-        type: 'pdf',
+        type: 'performance',
         portfolioId: 'portfolio-1',
+        dateRange: 'YTD',
+        format: 'pdf',
       };
 
       // Start export
       useExportStore.getState().startExport(config);
       expect(useExportStore.getState().progress.status).toBe('preparing');
 
-      // Update to exporting
+      // Update to generating
       useExportStore.getState().updateProgress({
-        status: 'exporting',
+        status: 'generating',
         progress: 30,
       });
-      expect(useExportStore.getState().progress.status).toBe('exporting');
+      expect(useExportStore.getState().progress.status).toBe('generating');
       expect(useExportStore.getState().progress.progress).toBe(30);
 
       // Progress to 60%
@@ -223,8 +230,10 @@ describe('Export Store', () => {
 
     it('should handle export failure workflow', () => {
       const config: ReportConfig = {
-        type: 'csv',
+        type: 'transactions',
         portfolioId: 'portfolio-1',
+        dateRange: 'ALL',
+        format: 'csv',
       };
 
       // Start export

--- a/src/lib/stores/__tests__/planning.test.ts
+++ b/src/lib/stores/__tests__/planning.test.ts
@@ -6,7 +6,6 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { usePlanningStore } from '../planning';
-import Decimal from 'decimal.js';
 
 // Mock database
 vi.mock('@/lib/db/schema', () => ({
@@ -15,15 +14,17 @@ vi.mock('@/lib/db/schema', () => ({
     addLiability: vi.fn(() => Promise.resolve()),
     updateLiability: vi.fn(() => Promise.resolve()),
     deleteLiability: vi.fn(() => Promise.resolve()),
-    getLiability: vi.fn((id) => Promise.resolve({
+    getLiability: vi.fn((id: string) => Promise.resolve({
       id,
       portfolioId: 'portfolio-1',
       name: 'Updated Name',
       type: 'loan',
-      initialBalance: new Decimal(10000),
-      interestRate: new Decimal(0.05),
-      startDate: new Date(),
-      monthlyPayment: new Decimal(200),
+      balance: 10000,
+      interestRate: 0.05,
+      startDate: '2023-01-01',
+      payment: 200,
+      createdAt: '2023-01-01T00:00:00.000Z',
+      updatedAt: '2023-06-01T00:00:00.000Z',
     })),
   },
 }));
@@ -34,11 +35,11 @@ describe('Planning Store', () => {
       fireConfig: {
         currentAge: 35,
         retirementAge: 65,
-        annualExpenses: new Decimal(40000),
-        safeWithdrawalRate: new Decimal(0.04),
-        expectedReturn: new Decimal(0.07),
-        currentSavings: new Decimal(100000),
-        monthlySavings: new Decimal(2000),
+        annualExpenses: 40000,
+        withdrawalRate: 0.04,
+        expectedReturn: 0.07,
+        inflationRate: 0.03,
+        monthlySavings: 2000,
       },
       liabilities: [],
       scenarios: [],
@@ -55,7 +56,7 @@ describe('Planning Store', () => {
     it('should have default FIRE configuration', () => {
       const state = usePlanningStore.getState();
       expect(state.fireConfig.retirementAge).toBe(65);
-      expect(state.fireConfig.safeWithdrawalRate.toNumber()).toBe(0.04);
+      expect(state.fireConfig.withdrawalRate).toBe(0.04);
     });
   });
 
@@ -67,9 +68,9 @@ describe('Planning Store', () => {
 
     it('should update annual expenses', () => {
       usePlanningStore.getState().setFireConfig({
-        annualExpenses: new Decimal(50000),
+        annualExpenses: 50000,
       });
-      expect(usePlanningStore.getState().fireConfig.annualExpenses.toNumber()).toBe(50000);
+      expect(usePlanningStore.getState().fireConfig.annualExpenses).toBe(50000);
     });
   });
 
@@ -80,11 +81,10 @@ describe('Planning Store', () => {
       await usePlanningStore.getState().addLiability({
         portfolioId: 'portfolio-1',
         name: 'Home Mortgage',
-        type: 'mortgage',
-        initialBalance: new Decimal(300000),
-        interestRate: new Decimal(0.04),
-        startDate: new Date('2023-01-01'),
-        monthlyPayment: new Decimal(1432.25),
+        balance: 300000,
+        interestRate: 0.04,
+        startDate: '2023-01-01',
+        payment: 1432.25,
       });
 
       expect(db.addLiability).toHaveBeenCalled();
@@ -102,11 +102,12 @@ describe('Planning Store', () => {
             id: 'liability-1',
             portfolioId: 'portfolio-1',
             name: 'Old Name',
-            type: 'loan',
-            initialBalance: new Decimal(10000),
-            interestRate: new Decimal(0.05),
-            startDate: new Date(),
-            monthlyPayment: new Decimal(200),
+            balance: 10000,
+            interestRate: 0.05,
+            startDate: '2023-01-01',
+            payment: 200,
+            createdAt: '2023-01-01T00:00:00.000Z',
+            updatedAt: '2023-01-01T00:00:00.000Z',
           },
         ],
       });
@@ -128,11 +129,12 @@ describe('Planning Store', () => {
             id: 'liability-1',
             portfolioId: 'portfolio-1',
             name: 'Test',
-            type: 'loan',
-            initialBalance: new Decimal(10000),
-            interestRate: new Decimal(0.05),
-            startDate: new Date(),
-            monthlyPayment: new Decimal(200),
+            balance: 10000,
+            interestRate: 0.05,
+            startDate: '2023-01-01',
+            payment: 200,
+            createdAt: '2023-01-01T00:00:00.000Z',
+            updatedAt: '2023-01-01T00:00:00.000Z',
           },
         ],
       });
@@ -148,10 +150,8 @@ describe('Planning Store', () => {
     it('should create FIRE scenario', () => {
       usePlanningStore.getState().addScenario({
         name: 'Optimistic',
-        fireConfig: {
-          ...usePlanningStore.getState().fireConfig,
-          expectedReturn: new Decimal(0.10),
-        },
+        type: 'market_correction',
+        value: 10,
         isActive: false,
       });
 
@@ -166,11 +166,11 @@ describe('Planning Store', () => {
         fireConfig: {
           currentAge: 50,
           retirementAge: 70,
-          annualExpenses: new Decimal(100000),
-          safeWithdrawalRate: new Decimal(0.05),
-          expectedReturn: new Decimal(0.10),
-          currentSavings: new Decimal(500000),
-          monthlySavings: new Decimal(5000),
+          annualExpenses: 100000,
+          withdrawalRate: 0.05,
+          expectedReturn: 0.10,
+          inflationRate: 0.03,
+          monthlySavings: 5000,
         },
       });
 


### PR DESCRIPTION
Update test files to match their corresponding type definitions:
- allocation.test.ts: Use valid AllocationDimension values and correct
  AllocationData shape (breakdown, totalValue, hasUnclassified)
- analysis.test.ts: Use overallScore instead of overall for PortfolioHealth,
  allocations instead of targets for TargetModel, isSystem instead of dimension
- export.test.ts: Use valid ReportType values (performance/transactions/holdings),
  add required dateRange and format fields, replace invalid 'exporting' status
  with 'generating'
- planning.test.ts: Use number types instead of Decimal for FireConfig fields,
  withdrawalRate instead of safeWithdrawalRate, correct Liability and Scenario shapes

https://claude.ai/code/session_01HJhDe3bZbR9diwvfTu3QkM