### PR TITLE
fix: resolve incorrect data display on tax analysis page

### DIFF
--- a/src/components/holdings/tax-analysis-tab.tsx
+++ b/src/components/holdings/tax-analysis-tab.tsx
@@ -74,8 +74,8 @@ export function TaxAnalysisTab({
 
   // Calculate tax analysis
   const taxAnalysis = useMemo(
-    () => estimateTaxLiability(holdings, prices, taxSettings),
-    [holdings, prices, taxSettings]
+    () => estimateTaxLiability(holdings, prices, taxSettings, assetSymbolMap),
+    [holdings, prices, taxSettings, assetSymbolMap]
   );
 
   // Handle column sorting
@@ -176,10 +176,19 @@ export function TaxAnalysisTab({
       {/* Summary Cards - Reduced to 3 for compactness */}
       <Grid numItemsMd={2} numItemsLg={3} className="gap-4">
         <Card>
-          <Text>Total Unrealized Gains</Text>
-          <Metric>${taxAnalysis.totalUnrealizedGain.toFixed(2)}</Metric>
+          <Text>Net Unrealized Gain/Loss</Text>
+          <Metric
+            className={cn(
+              taxAnalysis.netUnrealizedGain.lessThan(0) && 'text-red-600'
+            )}
+          >
+            ${taxAnalysis.netUnrealizedGain.toFixed(2)}
+          </Metric>
           <Flex className="mt-2">
-            <Text className="truncate text-sm">Net after losses</Text>
+            <Text className="truncate text-sm">
+              Gains: ${taxAnalysis.totalUnrealizedGain.toFixed(0)} / Losses: $
+              {taxAnalysis.totalUnrealizedLoss.toFixed(0)}
+            </Text>
           </Flex>
         </Card>
 

--- a/src/lib/services/tax-estimator.ts
+++ b/src/lib/services/tax-estimator.ts
@@ -34,7 +34,8 @@ import { calculateHoldingPeriod, calculateHoldingDays } from './holding-period';
 export function estimateTaxLiability(
   holdings: Holding[],
   currentPrices: Map<string, Decimal>,
-  taxSettings: TaxSettings
+  taxSettings: TaxSettings,
+  assetSymbolMap?: Map<string, string>
 ): TaxAnalysis {
   let totalUnrealizedGain = new Decimal(0);
   let totalUnrealizedLoss = new Decimal(0);
@@ -53,8 +54,8 @@ export function estimateTaxLiability(
       continue;
     }
 
-    // Use assetId as the symbol identifier
-    const assetSymbol = holding.assetId;
+    // Look up the actual ticker symbol, fall back to assetId if not found
+    const assetSymbol = assetSymbolMap?.get(holding.assetId) ?? holding.assetId;
 
     for (const lot of holding.lots) {
       // Skip fully sold lots


### PR DESCRIPTION
Two bugs caused the tax analysis page to show unrealistic data:

1. Asset column displayed internal UUIDs instead of ticker symbols.
   The tax estimator used holding.assetId (a UUID) as the display symbol,
   ignoring the assetSymbolMap that was already passed to the component
   but never forwarded to the calculation. Now estimateTaxLiability accepts
   an optional assetSymbolMap parameter and resolves symbols properly.

2. Summary card was mislabeled - showed gross gains under "Net after losses".
   The "Total Unrealized Gains" card displayed totalUnrealizedGain (only
   positive gains) but subtitled "Net after losses". Renamed to
   "Net Unrealized Gain/Loss" showing netUnrealizedGain with a gains/losses
   breakdown in the subtitle.

https://claude.ai/code/session_016k88JZ1f5sPt5ETuavQNZN