### PR TITLE
fix: prevent tax analysis content from disappearing during price polls

### DIFF
--- a/src/app/(dashboard)/tax-analysis/page.tsx
+++ b/src/app/(dashboard)/tax-analysis/page.tsx
@@ -30,7 +30,19 @@ export default function TaxAnalysisPage() {
     return map;
   }, [assets]);
 
-  // Convert prices to Map<string, Decimal>
+  // Create a stable key based on actual price values to prevent unnecessary re-renders
+  // This ensures pricesMap only changes when actual price values change, not on every poll cycle
+  const pricesKey = useMemo(
+    () =>
+      Object.entries(prices)
+        .filter(([, p]) => p != null)
+        .map(([id, p]) => `${id}:${p}`)
+        .sort()
+        .join('|'),
+    [prices]
+  );
+
+  // Convert prices to Map<string, Decimal> with stable dependency
   const pricesMap = useMemo(() => {
     const map = new Map<string, Decimal>();
     Object.entries(prices).forEach(([assetId, price]) => {
@@ -39,7 +51,8 @@ export default function TaxAnalysisPage() {
       }
     });
     return map;
-  }, [prices]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pricesKey]);
 
   if (!currentPortfolio) {
     return (

--- a/src/components/holdings/tax-analysis-tab.tsx
+++ b/src/components/holdings/tax-analysis-tab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState } from 'react';
 import Decimal from 'decimal.js';
 import { Card, Metric, Text, Flex, Grid } from '@tremor/react';
 import {
@@ -70,7 +70,6 @@ export function TaxAnalysisTab({
   const { taxSettings } = useTaxSettingsStore();
   const [sortField, setSortField] = useState<SortField>('purchaseDate');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
-  const [isCalculating, setIsCalculating] = useState(true);
 
   // Calculate tax analysis
   const taxAnalysis = useMemo(
@@ -123,12 +122,9 @@ export function TaxAnalysisTab({
     });
   }, [taxAnalysis.lots, sortField, sortDirection]);
 
-  // Simulate calculation delay for loading state
-  useEffect(() => {
-    setIsCalculating(true);
-    const timer = setTimeout(() => setIsCalculating(false), 100);
-    return () => clearTimeout(timer);
-  }, [holdings, prices, taxSettings]);
+  // Stable loading logic based on actual data state
+  // Only show loading if we have holdings but no tax lots AND no prices yet
+  const isLoading = holdings.length > 0 && taxAnalysis.lots.length === 0 && prices.size === 0;
 
   const SortButton = ({
     field,
@@ -150,8 +146,8 @@ export function TaxAnalysisTab({
     </Button>
   );
 
-  // Loading state
-  if (isCalculating) {
+  // Loading state - only show when genuinely waiting for price data
+  if (isLoading) {
     return (
       <div className="space-y-6">
         <Grid numItemsMd={2} numItemsLg={4} className="gap-6">

--- a/src/lib/services/tax-estimator.ts
+++ b/src/lib/services/tax-estimator.ts
@@ -50,7 +50,8 @@ export function estimateTaxLiability(
   for (const holding of holdings) {
     const currentPrice = currentPrices.get(holding.assetId);
     if (!currentPrice) {
-      // Skip holdings without current price
+      // Log skipped holdings for debugging - helps identify missing price data
+      console.warn(`Tax estimator: Skipping ${holding.assetId} - no price available`);
       continue;
     }
 


### PR DESCRIPTION
## Summary
- Remove artificial loading timer that caused content to flicker/disappear on every price poll cycle (15-60s)
- Stabilize pricesMap reference using value-based memoization key
- Add debug logging when holdings are skipped due to missing prices

## Root Causes Fixed
1. **Loading state flickers** - `useEffect` with `[holdings, prices, taxSettings]` deps triggered loading state on every price poll update
2. **Map reference instability** - `pricesMap` was recreated on every parent render, triggering child recalculations
3. **Silent data skipping** - Holdings without prices were silently skipped with no visibility

## Test plan
- [ ] Navigate to `/tax-analysis` with holdings
- [ ] Wait 30+ seconds (let price polling run multiple cycles)
- [ ] Verify content stays visible and doesn't flicker
- [ ] Switch portfolios - verify content loads correctly
- [ ] Check browser console for warnings about skipped holdings

🤖 Generated with [Claude Code](https://claude.ai/code)