### PR TITLE
feat: add CI workflow with merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,125 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+
+# Cancel in-progress runs on same PR/branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-typecheck:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npm run type-check
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test -- --run
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextjs-build
+          path: .next
+          retention-days: 1
+
+  e2e-tests:
+    name: E2E Tests (Chromium)
+    runs-on: ubuntu-latest
+    # Only run E2E tests in merge queue - not on regular PRs
+    if: github.event_name == 'merge_group'
+    needs: build
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nextjs-build
+          path: .next
+
+      - name: Install Playwright browsers (Chromium only)
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: npx playwright test --project=chromium
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Portfolio Tracker 📈
 
+[![CI](https://github.com/morgan8889/asset-portfolio/actions/workflows/ci.yml/badge.svg)](https://github.com/morgan8889/asset-portfolio/actions/workflows/ci.yml)
+
 A modern, privacy-first financial portfolio tracking application with interactive visualizations for multi-asset investment management and financial planning.
 
 ![Portfolio Tracker Dashboard](docs/designs/dashboard-preview.png)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -79,9 +79,6 @@ export default defineConfig({
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000, // 2 minutes
-    env: {
-      CI: 'true', // Explicitly set CI environment for consistency
-    },
   },
 
   /* Global test timeout */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -74,7 +74,8 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    // Use production server in CI for faster startup with pre-built artifacts
+    command: process.env.CI ? 'npm run start' : 'npm run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000, // 2 minutes

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -79,6 +79,9 @@ export default defineConfig({
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000, // 2 minutes
+    env: {
+      CI: 'true', // Explicitly set CI environment for consistency
+    },
   },
 
   /* Global test timeout */


### PR DESCRIPTION
## Summary
- Add unified CI workflow with two-tier strategy for faster PR feedback and thorough pre-merge validation
- Fast PR checks (~2-3 min): lint, typecheck, unit tests, build (run in parallel)
- Merge queue E2E tests: Chromium-only Playwright tests using pre-built artifacts
- Update Playwright config to use production server (`npm run start`) in CI

## Workflow Architecture
```
PR Created → Lint/TypeCheck + Unit Tests + Build (parallel, ~2-3 min)
     ↓
Approved → Add to Merge Queue
     ↓
E2E Tests (Chromium only, ~5-10 min)
     ↓
Merge → Main → Container Publish
```

## Required GitHub UI Configuration
After merging, configure branch protection for `main`:
- Require status checks: `Lint & Type Check`, `Unit Tests`, `Build`
- Enable merge queue with squash merge

## Test plan
- [ ] Verify fast checks run on PR (~2-3 min)
- [ ] Verify E2E tests only run in merge queue
- [ ] Verify build artifacts are correctly passed to E2E job

🤖 Generated with [Claude Code](https://claude.com/claude-code)