### PR TITLE
feat: tax lot pagination, E2E reliability, and test fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,20 @@ jobs:
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/run-e2e'))
 
     steps:
+      - name: Get PR head ref
+        if: github.event_name == 'issue_comment'
+        id: pr
+        run: |
+          PR_URL="${{ github.event.issue.pull_request.url }}"
+          PR_DATA=$(gh api "$PR_URL")
+          echo "ref=$(echo "$PR_DATA" | jq -r .head.ref)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.ref || '' }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -98,8 +110,20 @@ jobs:
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/run-e2e'))
 
     steps:
+      - name: Get PR head ref
+        if: github.event_name == 'issue_comment'
+        id: pr
+        run: |
+          PR_URL="${{ github.event.issue.pull_request.url }}"
+          PR_DATA=$(gh api "$PR_URL")
+          echo "ref=$(echo "$PR_DATA" | jq -r .head.ref)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.ref || '' }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/src/components/allocation/allocation-donut-chart.tsx
+++ b/src/components/allocation/allocation-donut-chart.tsx
@@ -154,45 +154,42 @@ const AllocationDonutChartComponent = ({
   return (
     <div className="grid gap-6 md:grid-cols-[1fr_1fr] lg:grid-cols-[3fr_2fr]">
       {/* Donut Chart */}
-      <div className="relative h-[350px] w-full md:h-[400px]">
-        <ResponsiveContainer width="100%" height="100%">
-          <PieChart>
-            <Pie
-              data={chartData}
-              cx="50%"
-              cy="50%"
-              labelLine={false}
-              label={renderCustomizedLabel}
-              outerRadius={120}
-              innerRadius={50}
-              fill="#8884d8"
-              dataKey="value"
-              strokeWidth={2}
-              stroke="white"
-              onClick={(data) => {
-                if (onCategoryClick) {
-                  onCategoryClick(data.name);
-                }
-              }}
-              cursor={onCategoryClick ? 'pointer' : 'default'}
-            >
-              {chartData.map((entry, index) => (
-                <Cell key={`cell-${index}`} fill={entry.color} />
-              ))}
-            </Pie>
-            <Tooltip content={<CustomTooltip />} />
-          </PieChart>
-        </ResponsiveContainer>
-
-        {/* Center Text */}
-        <div
-          className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center"
-          style={{ filter: 'drop-shadow(0 2px 4px rgba(0, 0, 0, 0.6))' }}
-        >
-          <div className="text-3xl font-bold text-white md:text-4xl">
+      <div className="flex flex-col items-center">
+        <div className="text-center -mb-12">
+          <div className="text-3xl font-bold md:text-4xl">
             {formatCurrency(totalValue)}
           </div>
-          <div className="text-sm text-white md:text-base">Total Value</div>
+          <div className="text-sm text-muted-foreground">Total Value</div>
+        </div>
+        <div className="relative h-[350px] w-full md:h-[400px]">
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={chartData}
+                cx="50%"
+                cy="50%"
+                labelLine={false}
+                label={renderCustomizedLabel}
+                outerRadius={120}
+                innerRadius={50}
+                fill="#8884d8"
+                dataKey="value"
+                strokeWidth={2}
+                stroke="white"
+                onClick={(data) => {
+                  if (onCategoryClick) {
+                    onCategoryClick(data.name);
+                  }
+                }}
+                cursor={onCategoryClick ? 'pointer' : 'default'}
+              >
+                {chartData.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={entry.color} />
+                ))}
+              </Pie>
+              <Tooltip content={<CustomTooltip />} />
+            </PieChart>
+          </ResponsiveContainer>
         </div>
       </div>
 

--- a/src/components/allocation/allocation-donut-chart.tsx
+++ b/src/components/allocation/allocation-donut-chart.tsx
@@ -155,6 +155,9 @@ const AllocationDonutChartComponent = ({
     <div className="grid gap-6 md:grid-cols-[1fr_1fr] lg:grid-cols-[3fr_2fr]">
       {/* Donut Chart */}
       <div className="flex flex-col items-center">
+        {/* Total value header positioned above donut chart with negative margin to create visual overlap.
+            -mb-12 (48px) allows the total value text to sit in the donut center while remaining
+            above the chart in DOM order, preventing text cutoff issues. */}
         <div className="text-center -mb-12">
           <div className="text-3xl font-bold md:text-4xl">
             {formatCurrency(totalValue)}

--- a/src/components/forms/__tests__/create-portfolio-edit.test.tsx
+++ b/src/components/forms/__tests__/create-portfolio-edit.test.tsx
@@ -120,8 +120,8 @@ describe('CreatePortfolioDialog - Edit Mode', () => {
   });
 
   it.skip('should show warning when changing type with existing transactions', async () => {
-    // Note: This test is skipped due to jsdom limitations with Radix UI Select pointer events.
-    // The functionality is covered by E2E tests in tests/e2e/portfolio-edit.spec.ts
+    // Skip: Radix Select inside Radix Dialog doesn't register value changes in jsdom
+    // (Dialog sets pointer-events:none on body). Covered by E2E: portfolio-edit.spec.ts
     const user = userEvent.setup();
     const mockCountTransactions = vi.fn(() => Promise.resolve(5));
     

--- a/src/components/tables/__tests__/holdings-table.test.tsx
+++ b/src/components/tables/__tests__/holdings-table.test.tsx
@@ -257,10 +257,7 @@ describe('HoldingsTable', () => {
       });
     });
 
-    // SKIP: Radix UI Select component uses hasPointerCapture which is not implemented in jsdom
-    // This is a known limitation: https://github.com/radix-ui/primitives/issues/420
-    // The component works correctly in real browsers and E2E tests should cover this
-    it.skip('should filter by asset type', async () => {
+    it('should filter by asset type', async () => {
       render(<HoldingsTable />);
 
       const filterSelect = screen.getByRole('combobox');
@@ -278,10 +275,7 @@ describe('HoldingsTable', () => {
       });
     });
 
-    // SKIP: Radix UI Select component uses hasPointerCapture which is not implemented in jsdom
-    // This is a known limitation: https://github.com/radix-ui/primitives/issues/420
-    // The component works correctly in real browsers and E2E tests should cover this
-    it.skip('should combine search and filter', async () => {
+    it('should combine search and filter', async () => {
       render(<HoldingsTable />);
 
       // Filter by stock type

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -7,6 +7,12 @@ import { beforeEach, afterEach, vi } from 'vitest';
 // Mock scrollIntoView - used by Radix UI Select component
 HTMLElement.prototype.scrollIntoView = vi.fn();
 
+// Mock pointer capture APIs - used by Radix UI Select and other Radix components
+// jsdom doesn't implement these: https://github.com/radix-ui/primitives/issues/420
+HTMLElement.prototype.setPointerCapture = vi.fn();
+HTMLElement.prototype.releasePointerCapture = vi.fn();
+HTMLElement.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+
 // Mock ResizeObserver - used by Radix UI Popover, Dialog components
 global.ResizeObserver = vi.fn().mockImplementation(() => ({
   observe: vi.fn(),

--- a/tests/e2e/allocation-responsive-layout.spec.ts
+++ b/tests/e2e/allocation-responsive-layout.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Allocation Responsive Layout', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to the allocation page
+    await seedMockData(page);
     await page.goto('/allocation');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test('should display allocation page with three tabs', async ({ page }) => {

--- a/tests/e2e/charts-visualization.spec.ts
+++ b/tests/e2e/charts-visualization.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Charts and Visualization', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to the dashboard
+    await seedMockData(page);
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test('should display portfolio performance chart', async ({ page }) => {

--- a/tests/e2e/csv-import.spec.ts
+++ b/tests/e2e/csv-import.spec.ts
@@ -4,7 +4,7 @@
  * Tests the complete user workflow for importing transactions from CSV files.
  */
 
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 import path from 'path';
 
 // Test CSV file content
@@ -20,7 +20,7 @@ invalid-date,GOOGL,5,175.50,buy
 
 test.describe('CSV Import Flow', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to transactions page
+    await seedMockData(page);
     await page.goto('/transactions');
   });
 
@@ -257,6 +257,7 @@ test.describe('Manual Column Mapping Correction', () => {
 2025-01-16,GOOGL,5,175.50,SELL`;
 
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     await page.goto('/transactions');
   });
 
@@ -387,6 +388,7 @@ invalid-date,GOOGL,5,175.50,buy
 2025-01-19,NVDA,25,450.00,buy`;
 
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     await page.goto('/transactions');
   });
 
@@ -490,6 +492,7 @@ test.describe('Import with Duplicate Detection', () => {
   // These tests verify the basic import workflow - actual duplicate detection is tested in unit tests.
 
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     await page.goto('/transactions');
   });
 

--- a/tests/e2e/dashboard-chart.spec.ts
+++ b/tests/e2e/dashboard-chart.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 /**
  * E2E tests for the Growth Chart Widget (US2)
@@ -7,8 +7,9 @@ import { test, expect } from './fixtures/test';
  */
 test.describe('Dashboard Growth Chart', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test.describe('Time Range Selection', () => {

--- a/tests/e2e/dashboard-configuration.spec.ts
+++ b/tests/e2e/dashboard-configuration.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 /**
  * E2E tests for Dashboard Widget Configuration (US3)
@@ -8,8 +8,9 @@ import { test, expect } from './fixtures/test';
  */
 test.describe('Dashboard Widget Configuration', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test.describe('Settings Modal', () => {

--- a/tests/e2e/dashboard-display.spec.ts
+++ b/tests/e2e/dashboard-display.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 /**
  * E2E tests for the Configurable Dashboard Display (US1)
@@ -8,8 +8,9 @@ import { test, expect } from './fixtures/test';
  */
 test.describe('Configurable Dashboard Display', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test.describe('Widget Display', () => {

--- a/tests/e2e/dashboard-performance.spec.ts
+++ b/tests/e2e/dashboard-performance.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 /**
  * E2E tests for Dashboard Performance (T061, T062)
@@ -8,6 +8,10 @@ import { test, expect } from './fixtures/test';
  * - SC-004: Chart range change < 1s
  */
 test.describe('Dashboard Performance', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
+  });
+
   test.describe('Dashboard Load Time (SC-001)', () => {
     test('should load dashboard within 2 seconds', async ({ page }) => {
       const startTime = Date.now();

--- a/tests/e2e/dashboard-performers.spec.ts
+++ b/tests/e2e/dashboard-performers.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 /**
  * E2E tests for Top Performers and Biggest Losers Widgets (US4)
@@ -7,8 +7,9 @@ import { test, expect } from './fixtures/test';
  */
 test.describe('Dashboard Performers Widgets', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test.describe('Top Performers Widget', () => {

--- a/tests/e2e/dashboard-responsive.spec.ts
+++ b/tests/e2e/dashboard-responsive.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 /**
  * E2E tests for Dashboard Responsive Layout (T060)
@@ -21,9 +21,10 @@ test.describe('Dashboard Responsive Layout', () => {
   for (const vp of viewports) {
     test.describe(`${vp.name} (${vp.width}x${vp.height})`, () => {
       test.beforeEach(async ({ page }) => {
+        await seedMockData(page);
         await page.setViewportSize({ width: vp.width, height: vp.height });
         await page.goto('/');
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('load');
       });
 
       test('should render without horizontal overflow', async ({ page }) => {

--- a/tests/e2e/dashboard-settings-viewport.spec.ts
+++ b/tests/e2e/dashboard-settings-viewport.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 /**
  * E2E tests for Dashboard Settings Dialog Viewport Constraints
@@ -8,8 +8,9 @@ import { test, expect } from './fixtures/test';
  */
 test.describe('Dashboard Settings Dialog Viewport', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test('should display title at top of dialog', async ({ page }) => {

--- a/tests/e2e/dashboard-time-period.spec.ts
+++ b/tests/e2e/dashboard-time-period.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 /**
  * E2E tests for Time Period Selection (US5)
@@ -7,8 +7,9 @@ import { test, expect } from './fixtures/test';
  */
 test.describe('Dashboard Time Period Selection', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test.describe('Time Period Selector', () => {

--- a/tests/e2e/dividend-workflow.spec.ts
+++ b/tests/e2e/dividend-workflow.spec.ts
@@ -12,10 +12,11 @@
  * - Test reinvested dividends
  */
 
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Dividend Workflow', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     // Navigate to dashboard
     await page.goto('/');
     await expect(page.getByText(/portfolio dashboard/i)).toBeVisible({ timeout: 10000 });

--- a/tests/e2e/espp-workflow.spec.ts
+++ b/tests/e2e/espp-workflow.spec.ts
@@ -5,13 +5,13 @@
  * including metadata entry, lot viewing, and tax analysis.
  */
 
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('ESPP Workflow', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to the dashboard and wait for it to load
+    await seedMockData(page);
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test('should add ESPP purchase transaction with all metadata', async ({ page }) => {

--- a/tests/e2e/fixtures/test.ts
+++ b/tests/e2e/fixtures/test.ts
@@ -103,3 +103,15 @@ export const test = base.extend<{ mockPriceApi: void }>({
 });
 
 export { expect, type Page } from '@playwright/test';
+
+/**
+ * Navigate to /test, generate mock portfolio data, and wait for completion.
+ * Call this in beforeEach for tests that need portfolio/holdings/transaction data.
+ * Does NOT wait for the auto-redirect — the caller's next page.goto() cancels it.
+ */
+export async function seedMockData(page: import('@playwright/test').Page) {
+  await page.goto('/test');
+  const btn = page.getByRole('button', { name: 'Generate Mock Data' });
+  await btn.click();
+  await page.getByText('Done! Redirecting...').waitFor({ timeout: 15000 });
+}

--- a/tests/e2e/holdings-detail-modal.spec.ts
+++ b/tests/e2e/holdings-detail-modal.spec.ts
@@ -12,10 +12,11 @@
  * - Verifying updates persist
  */
 
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Holdings Detail Modal', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     // Navigate to dashboard
     await page.goto('/');
     await expect(page.getByText(/portfolio dashboard/i)).toBeVisible({ timeout: 10000 });

--- a/tests/e2e/holdings-table.spec.ts
+++ b/tests/e2e/holdings-table.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Holdings Table', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to the dashboard
+    await seedMockData(page);
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test('should display holdings table when data exists', async ({ page }) => {

--- a/tests/e2e/navigation-bug.spec.ts
+++ b/tests/e2e/navigation-bug.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 /**
  * Regression test for navigation bug where AppInitializer
@@ -8,6 +8,10 @@ import { test, expect } from './fixtures/test';
  * remount, causing pages to hang on "Initializing..." forever.
  */
 test.describe('Navigation across dashboard pages', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
+  });
+
   test('should navigate to Holdings page without timeout', async ({ page }) => {
     // Navigate to dashboard first
     await page.goto('/');

--- a/tests/e2e/planning.spec.ts
+++ b/tests/e2e/planning.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Net Worth Planning & FIRE Feature', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to the planning page directly
+    await seedMockData(page);
     await page.goto('/planning');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test('should load planning page with all sections', async ({ page }) => {

--- a/tests/e2e/portfolio-delete.spec.ts
+++ b/tests/e2e/portfolio-delete.spec.ts
@@ -1,9 +1,10 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Portfolio Delete Workflow', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     await page.goto('/portfolios');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test('should open delete dialog when clicking Delete button', async ({ page }) => {

--- a/tests/e2e/portfolio-edit.spec.ts
+++ b/tests/e2e/portfolio-edit.spec.ts
@@ -1,9 +1,10 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Portfolio Edit Workflow', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     await page.goto('/portfolios');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test('should open edit dialog when clicking Edit button', async ({ page }) => {

--- a/tests/e2e/portfolio-switching.spec.ts
+++ b/tests/e2e/portfolio-switching.spec.ts
@@ -1,9 +1,10 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Portfolio Switching', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test('should switch between portfolios and update dashboard', async ({ page }) => {
@@ -47,6 +48,7 @@ test.describe('Portfolio Switching', () => {
 
 test.describe('Filter State Preservation Across Portfolio Switches', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     await page.goto('/');
     await page.waitForLoadState('networkidle');
   });

--- a/tests/e2e/portfolio-ytd-return.spec.ts
+++ b/tests/e2e/portfolio-ytd-return.spec.ts
@@ -3,10 +3,11 @@
  * @module tests/e2e/portfolio-ytd-return.spec
  */
 
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Portfolio YTD Return Display', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     // Navigate to the portfolios page
     await page.goto('/portfolios');
 

--- a/tests/e2e/portfolios-management.spec.ts
+++ b/tests/e2e/portfolios-management.spec.ts
@@ -1,9 +1,10 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Portfolios Management Page', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     await page.goto('/portfolios');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test('should navigate to /portfolios route', async ({ page }) => {

--- a/tests/e2e/property-addition.spec.ts
+++ b/tests/e2e/property-addition.spec.ts
@@ -1,14 +1,12 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Property Addition Workflow', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to app and ensure clean state
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await seedMockData(page);
 
     // Ensure we're on the holdings page
     await page.goto('/holdings');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test('T021.1: should add basic property in under 30 seconds (SC-001)', async ({

--- a/tests/e2e/real-estate-filter.spec.ts
+++ b/tests/e2e/real-estate-filter.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 /**
  * Helper function to add a property via UI
@@ -81,9 +81,10 @@ async function addStock(
 
 test.describe('Real Estate Filter (SC-003)', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     // Navigate to holdings page
     await page.goto('/holdings');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test('T023.1: should filter to show only Real Estate assets', async ({

--- a/tests/e2e/rebalancing-execution.spec.ts
+++ b/tests/e2e/rebalancing-execution.spec.ts
@@ -12,10 +12,11 @@
  * - Test rebalancing with exclusions
  */
 
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Rebalancing Execution', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     // Navigate to dashboard
     await page.goto('/');
     await expect(page.getByText(/portfolio dashboard/i)).toBeVisible({ timeout: 10000 });

--- a/tests/e2e/rsu-workflow.spec.ts
+++ b/tests/e2e/rsu-workflow.spec.ts
@@ -5,13 +5,13 @@
  * including net shares calculation, tax withholding, and metadata display.
  */
 
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('RSU Workflow', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to the dashboard and wait for it to load
+    await seedMockData(page);
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test('should add RSU vest transaction with all metadata', async ({ page }) => {

--- a/tests/e2e/sell-workflow.spec.ts
+++ b/tests/e2e/sell-workflow.spec.ts
@@ -12,10 +12,11 @@
  * - Holdings update verification
  */
 
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Sell Workflow', () => {
   test.beforeEach(async ({ page }) => {
+    await seedMockData(page);
     // Navigate to dashboard and ensure it's loaded
     await page.goto('/');
     await expect(page.getByText(/portfolio dashboard/i)).toBeVisible({ timeout: 10000 });

--- a/tests/e2e/tax-analysis-view.spec.ts
+++ b/tests/e2e/tax-analysis-view.spec.ts
@@ -9,11 +9,11 @@
  * - Estimated tax liability calculations
  */
 
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Tax Analysis View', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to the dashboard and wait for it to load
+    await seedMockData(page);
     await page.goto('/');
     await page.waitForLoadState('networkidle');
   });

--- a/tests/e2e/transaction-management.spec.ts
+++ b/tests/e2e/transaction-management.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect } from './fixtures/test';
+import { test, expect, seedMockData } from './fixtures/test';
 
 test.describe('Transaction Management', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to the dashboard and wait for it to load
+    await seedMockData(page);
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
   });
 
   test('should open add transaction dialog', async ({ page }) => {


### PR DESCRIPTION
## Summary

- **Tax lot pagination**: Add pagination to the tax lot analysis table for portfolios with many lots
- **E2E test reliability**: Add `seedMockData` helper + mock price API fixture to 30 E2E test files, ensuring IndexedDB is populated before each test. Replace `networkidle` with `load` wait strategy (~4-5s savings per test)
- **Unit test fixes**: Add pointer capture API mocks to global test setup for Radix UI Select compatibility in jsdom. Unskip 2 previously skipped holdings-table filter tests (1612 pass, 1 skip)
- **Allocation chart fix**: Move total portfolio value above the donut chart to prevent text overlap/cutoff

## Test plan

- [ ] `npm run type-check` passes
- [ ] `npm run test -- --run` — 1612 passed, 1 skipped
- [ ] `npx playwright test --project=chromium` — 287 passed, 0 failed
- [ ] Verify allocation donut chart displays total value above chart without cutoff
- [ ] Verify tax lot table paginates correctly with many lots

🤖 Generated with [Claude Code](https://claude.com/claude-code)