### PR TITLE
fix: add output standalone to fix Docker container build

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'standalone',
   experimental: {
     typedRoutes: true,
     optimizePackageImports: ['recharts', 'date-fns', 'lucide-react'],


### PR DESCRIPTION
## Summary
- Adds `output: 'standalone'` to `next.config.mjs`
- Fixes the `Build and Publish Container` workflow which has been failing since project setup with: `failed to compute cache key: "/app/.next/standalone": not found`
- Without this setting Next.js never emits `.next/standalone/`, so the Dockerfile `COPY` step fails

## Test plan
- [ ] `Build and Publish Container` workflow passes on merge to `main`
- [ ] `.next/standalone/server.js` present in build output (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)